### PR TITLE
Spring REST Docs 의존성 추가

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,6 +13,9 @@ plugins {
     // Spring
     id 'org.springframework.boot' version '2.3.5.RELEASE'
     id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+
+    // Asciidoctor
+    id 'org.asciidoctor.convert' version '2.4.0'
 }
 
 sourceCompatibility = '1.8'
@@ -78,6 +81,10 @@ dependencies {
     testImplementation('org.springframework.boot:spring-boot-starter-test') {
         exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
     }
+
+    // Spring REST Docs
+    asciidoctor 'org.springframework.restdocs:spring-restdocs-asciidoctor'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 }
 
 application {
@@ -88,4 +95,10 @@ application {
 tasks.named('test') {
     // Use junit platform for unit tests.
     useJUnitPlatform()
+}
+
+
+// asciidoc가 실행되기전에 test를 먼저 하기 위함
+asciidoctor {
+    dependsOn(test)
 }


### PR DESCRIPTION
Spring REST Docs는 Asciidoc로 작성된 문서와 Spring MVC Test을 API문서 템플릿(snippets)으로 자동 생성해줍니다.