### PR TITLE
Spring REST Docs 의존성 추가

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,6 +13,7 @@ plugins {
     // Spring
     id 'org.springframework.boot' version '2.3.5.RELEASE'
     id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+    id 'org.asciidoctor.convert' version '2.4.0'
 }
 
 sourceCompatibility = '1.8'
@@ -71,6 +72,10 @@ dependencies {
     // Spring Security
     implementation 'org.springframework.boot:spring-boot-starter-security'
 
+    // Spring REST Docs
+    asciidoctor 'org.springframework.restdocs:spring-restdocs-asciidoctor'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+
     // Spring Developer Tools
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
@@ -83,6 +88,10 @@ dependencies {
 application {
     // Define the main class for the application.
     mainClass = 'com.codesoom.assignment.App'
+}
+
+asciidoctor {
+    dependsOn test
 }
 
 tasks.named('test') {


### PR DESCRIPTION
Spring REST Docs 의존성을 추가했습니다.

Spring REST Docs는 테스트 코드를 이용해 RESTful 서비스의 API 문서를 작성할 수 있게 도와주는 라이브러리 입니다.

Spring MockMvc 테스트를 이용해 API 문서를 작성할 수 있으며,
테스트가 통과되어 스니펫들이 생성되면 `build/generated-snippets` 경로에 `.adoc` 파일들이 생성됩니다.
생성된 스니펫들은 `src/docs/asciidoc` 경로에 `.adoc` 파일을 작성하여 생성된 스니펫 파일들을 포함시킬 수 있습니다.

자세한 내용은 공식 문서를 참고해주시기 바랍니다.

참고
[Spring REST Docs](https://docs.spring.io/spring-restdocs/docs/current/reference/html5/#introduction)