### PR TITLE
Spring REST Docs 의존성 추가

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,6 +13,9 @@ plugins {
     // Spring
     id 'org.springframework.boot' version '2.3.5.RELEASE'
     id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+
+    // Asciidoctor
+    id "org.asciidoctor.jvm.convert" version '3.3.2'
 }
 
 sourceCompatibility = '1.8'
@@ -74,10 +77,23 @@ dependencies {
     // Spring Developer Tools
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
+    // Spring Rest Docs
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+
     // Spring Boot Test
     testImplementation('org.springframework.boot:spring-boot-starter-test') {
         exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
     }
+}
+
+ext {
+    // snippet 이 생성 될 위치
+    snippetsDir = file('build/generated-snippets')
+}
+
+asciidoctor {
+    inputs.dir snippetsDir
+    dependsOn test // build 시 test -> asciidoctor 순으로 수행
 }
 
 application {

--- a/app/src/docs/asciidoc/index.adoc
+++ b/app/src/docs/asciidoc/index.adoc
@@ -1,17 +1,12 @@
 = 고양이 장난감 가게 API
 
-== GET /products
 
-상품 목록을 JSON 형태로 돌려준다.
+== 상품
+=== 상품 리스트
+`GET` 요청으로 상품 리스트를 조회합니다.
 
-include::{snippets}/get-products/http-request.adoc[]
+*요청*
+include::{snippets}/product-list/http-request.adoc[]
 
-include::{snippets}/get-products/http-response.adoc[]
-
-== GET /product/{id}
-
-상품에 대한 자세한 정보를 JSON 형태로 돌려준다.
-
-include::{snippets}/get-product/http-request.adoc[]
-
-include::{snippets}/get-product/http-response.adoc[]
+*응답*
+include::{snippets}/product-list/http-response.adoc[]

--- a/app/src/test/java/com/codesoom/assignment/controllers/ProductControllerTest.java
+++ b/app/src/test/java/com/codesoom/assignment/controllers/ProductControllerTest.java
@@ -8,8 +8,11 @@ import com.codesoom.assignment.dto.ProductData;
 import com.codesoom.assignment.errors.InvalidTokenException;
 import com.codesoom.assignment.errors.ProductNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
@@ -23,11 +26,16 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(ProductController.class)
+@AutoConfigureRestDocs
 class ProductControllerTest {
     private static final String VALID_TOKEN = "eyJhbGciOiJIUzI1NiJ9." +
             "eyJ1c2VySWQiOjF9.ZZ3CUl0jxeLGvQ1Js5nG2Ty5qGTlqai5ubDMXZOdaDk";
@@ -90,13 +98,18 @@ class ProductControllerTest {
     }
 
     @Test
-    void list() throws Exception {
+    void productList() throws Exception {
         mockMvc.perform(
                 get("/products")
                         .accept(MediaType.APPLICATION_JSON_UTF8)
         )
                 .andExpect(status().isOk())
-                .andExpect(content().string(containsString("쥐돌이")));
+                .andExpect(content().string(containsString("쥐돌이")))
+                .andDo(document("{method-name}",
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint())
+                        )
+                );
     }
 
     @Test


### PR DESCRIPTION
**Spring REST Docs** 추가했습니다.

**Spring REST Docs** 은
Spring MVC Test, WebTestClient 등 테스트에서 생성된 스니펫을 사용하여
RESTful 서비스에 대한 정확하고 읽기 쉬운 문서를 생성해 줍니다.

기본적으로 `Asciidoctor` 를 사용하고
`Asciidoctor` 텍스트를 처리하고 필요에 맞게 스타일이 지정되고 배치된 HTML 을 생성합니다.
`Markdown` 을 사용할 수도 있습니다.

[Spring REST Docs](https://docs.spring.io/spring-restdocs/docs/current/reference/html5/)

---

상품 리스트 테스트에 샘플로 적용해봤습니다. 35dbc44001e1d5f85f7acfc0bfe7556f1f4de76d

