### PR TITLE
자바 버전 변경

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,7 +15,7 @@ plugins {
     id 'io.spring.dependency-management' version '1.0.10.RELEASE'
 }
 
-sourceCompatibility = '1.8'
+sourceCompatibility = '11'
 
 configurations {
     developmentOnly


### PR DESCRIPTION
자바 버전을 1.8에서 11로 변경하였습니다.

현재 `sourceCompatibility`가 1.8로 설정되어 있었는데, 
`List.of` 메서드를 사용하는 코드에서 아래와 같은 에러가 발생해 빌드에 실패하는 문제가 발생했습니다.
```
java: cannot find symbol
  symbol:   method of(java.lang.String,java.lang.String,java.lang.String,java.lang.String,java.lang.String,java.lang.String,java.lang.String,java.lang.String,java.lang.String,java.lang.String)
  location: interface java.util.List
```
원인은 `List.of` 메서드가 자바9 버전 부터 지원되기 때문이며, 11 버전으로 변경 후 호환성에 문제가 없는 것을 확인했습니다.

**참고**
[List.of](https://docs.oracle.com/javase/9/docs/api/java/util/List.html#of-E-)