### PR TITLE
Spring REST Docs 의존성 추가

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -13,12 +13,16 @@ plugins {
     // Spring
     id 'org.springframework.boot' version '2.3.5.RELEASE'
     id 'io.spring.dependency-management' version '1.0.10.RELEASE'
+
+    // asciidoc파일을 변환해주고, Build폴더에 복사해주는 플러그
+    id "org.asciidoctor.jvm.convert" version '3.3.2'
 }
 
 sourceCompatibility = '1.8'
 
 configurations {
     developmentOnly
+    asciidoctorExt
     runtimeClasspath {
         extendsFrom developmentOnly
     }
@@ -78,6 +82,9 @@ dependencies {
     testImplementation('org.springframework.boot:spring-boot-starter-test') {
         exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
     }
+
+    // Spring REST Docs
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 }
 
 application {
@@ -85,7 +92,23 @@ application {
     mainClass = 'com.codesoom.assignment.App'
 }
 
-tasks.named('test') {
-    // Use junit platform for unit tests.
+test {
     useJUnitPlatform()
+}
+
+ext {
+    // snippet 이 생성 될 위치
+    snippetsDir = file('build/generated-snippets')
+}
+
+asciidoctor {
+    inputs.dir snippetsDir
+    dependsOn test // gradle build 시 test -> asciidoctor 순으로 수행
+}
+
+bootJar {
+    dependsOn asciidoctor    // gradle build 시 asciidoctor 순으로 수행
+    from("${asciidoctor.outputDir}/html5") {    // gradle build 시 ./build/asciidoc/html5/ 에 html 파일생성
+        into 'static/docs'                        // html 파일이 jar 안의 /static/docs/ 폴더로 복사됨
+    }
 }

--- a/app/src/docs/asciidoc/index.adoc
+++ b/app/src/docs/asciidoc/index.adoc
@@ -1,17 +1,84 @@
 = 고양이 장난감 가게 API
 
+== 참고
+Response
+
+|===
+|Path|Type|Description
+
+|`+result+`
+|`+String+`
+|응답 결과
+
+|`+message+`
+|`+String+`
+|응답 메세지
+
+|`+data+`
+|`+Array+`
+|응답 Data
+
+|`+errorMessage+`
+|`+String+`
+|에러 메세지
+
+|===
+
 == GET /products
 
-상품 목록을 JSON 형태로 돌려준다.
+=== Request
 
-include::{snippets}/get-products/http-request.adoc[]
+==== URL
+----
+GET /products HTTP/1.1
+Accept: application/json;charset=UTF-8
+Host: localhost:8080
+----
 
-include::{snippets}/get-products/http-response.adoc[]
+=== Response
+|===
+|Path|Type|Description
 
-== GET /product/{id}
+|`+id+`
+|`+Number+`
+|상품 id
 
-상품에 대한 자세한 정보를 JSON 형태로 돌려준다.
+|`+name+`
+|`+String+`
+|상품명
 
-include::{snippets}/get-product/http-request.adoc[]
+|`+maker+`
+|`+String+`
+|상품 제조사
 
-include::{snippets}/get-product/http-response.adoc[]
+|`+price+`
+|`+Number+`
+|상품 가격
+
+|`+imageUrl+`
+|`+String+`
+|상품 url
+
+|===
+
+=== Sample
+==== Request(상품 목록 요청)
+----
+$ curl 'http://localhost:8080/products' -i -X GET \
+    -H 'Accept: application/json;charset=UTF-8'
+----
+==== Response(상품 목록 응답)
+----
+{
+  "result" : "SUCCESS",
+  "data" : [ {
+    "id" : 1,
+    "name" : "쥐돌이",
+    "maker" : "냥이월드",
+    "price" : 5000,
+    "imageUrl" : null
+  } ],
+  "message" : null,
+  "errorMessage" : null
+}
+----

--- a/app/src/main/java/com/codesoom/assignment/common/Builder.java
+++ b/app/src/main/java/com/codesoom/assignment/common/Builder.java
@@ -1,0 +1,6 @@
+package com.codesoom.assignment.common;
+
+public interface Builder<T> {
+    T build();
+
+}

--- a/app/src/main/java/com/codesoom/assignment/common/CommonResponse.java
+++ b/app/src/main/java/com/codesoom/assignment/common/CommonResponse.java
@@ -1,0 +1,110 @@
+package com.codesoom.assignment.common;
+
+public class CommonResponse<T> {
+    private Result result;
+    private T data;
+    private String message;
+    private String errorMessage;
+
+    public static <T> CommonResponse success(T data, String message) {
+        return new CommonResponseBuilder().result(Result.SUCCESS)
+                .data(data)
+                .message(message)
+                .build();
+    }
+
+
+    public static <T> CommonResponse success(T data) {
+        return success(data, null);
+    }
+
+    public static <T> CommonResponse success(String message) {
+        return success(null, message);
+    }
+
+    public static CommonResponse fail(String message, String errorCode) {
+        return new CommonResponseBuilder().result(Result.FAIL)
+                .message(message)
+                .errorCode(errorCode)
+                .build();
+    }
+
+//    public static CommonResponse fail(ErrorMessage errorCode) {
+//
+//        return new CommonResponseBuilder().result(Result.FAIL)
+//                .message(errorCode.getErrorMsg())
+//                .errorCode(errorCode.name())
+//                .build();
+//    }
+
+    public static CommonResponse fail(String errorCode) {
+        return new CommonResponseBuilder().result(Result.FAIL)
+                .errorCode(errorCode)
+                .build();
+    }
+
+    public enum Result {
+        SUCCESS, FAIL
+    }
+
+    public Object getData() {
+        return data;
+    }
+
+    public Object getMessage() {
+        return message;
+    }
+
+    public Result getResult() {
+        return result;
+    }
+
+    public String getErrorMessage() {
+        return errorMessage;
+    }
+
+    private CommonResponse(CommonResponseBuilder commonResponseBuilder) {
+        this.result = commonResponseBuilder.result;
+        this.data = (T) commonResponseBuilder.data;
+        this.message = commonResponseBuilder.message;
+        this.errorMessage = commonResponseBuilder.errorMessage;
+    }
+
+    public static class CommonResponseBuilder implements Builder<CommonResponse> {
+        private Result result;
+        private Object data;
+        private String message;
+        private String errorMessage;
+
+        private CommonResponseBuilder() {
+        }
+
+        public CommonResponseBuilder data(Object data) {
+            this.data = data;
+            return this;
+        }
+
+        public CommonResponseBuilder result(Result result) {
+            this.result = result;
+            return this;
+        }
+
+        public CommonResponseBuilder message(String message) {
+            this.message = message;
+            return this;
+
+        }
+
+        public CommonResponseBuilder errorCode(String errorMessage) {
+            this.errorMessage = errorMessage;
+            return this;
+        }
+
+        @Override
+        public CommonResponse build() {
+            return new CommonResponse(this);
+        }
+    }
+
+
+}

--- a/app/src/main/java/com/codesoom/assignment/controllers/ProductController.java
+++ b/app/src/main/java/com/codesoom/assignment/controllers/ProductController.java
@@ -2,6 +2,7 @@ package com.codesoom.assignment.controllers;
 
 import com.codesoom.assignment.application.AuthenticationService;
 import com.codesoom.assignment.application.ProductService;
+import com.codesoom.assignment.common.CommonResponse;
 import com.codesoom.assignment.domain.Product;
 import com.codesoom.assignment.dto.ProductData;
 import org.springframework.http.HttpStatus;
@@ -11,6 +12,9 @@ import org.springframework.web.bind.annotation.*;
 import javax.validation.Valid;
 import java.util.List;
 
+/**
+ * 클라이언트로 부터 crud 요청과 요청에 대한 응답을 처리하는 controller입니다
+ */
 @RestController
 @RequestMapping("/products")
 public class ProductController {
@@ -24,16 +28,37 @@ public class ProductController {
         this.authenticationService = authenticationService;
     }
 
+    /**
+     * 등록된 모든 상품 목록과 상태코드 200을 응답합니다
+     *
+     * @return 모든 상품 목록
+     */
     @GetMapping
-    public List<Product> list() {
-        return productService.getProducts();
+    public CommonResponse<List<Product>> list() {
+        List<Product> list = productService.getProducts();
+        return CommonResponse.success(list);
     }
 
+    /**
+     * 등록된 상품중 id에 해당하는 상품 상세 정보와 상태코드 200을 응답합니다.
+     *
+     * @param id 상품의 id
+     * @return id에 해당하는 상품의 상세 정보
+     */
     @GetMapping("{id}")
+    @ResponseStatus(HttpStatus.OK)
     public Product detail(@PathVariable Long id) {
         return productService.getProduct(id);
     }
 
+    /**
+     * 로그인이 되어있고, 권한이 USER인 경우
+     * 새로운 상품 등록 요청을 처리합니다.
+     * 상품을 등록하면 상태코드 201과 등록된 상품을 응답합니다
+     *
+     * @param productData 등록하고자 하는 상품의 정보
+     * @return 등록된 상품정보
+     */
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     @PreAuthorize("isAuthenticated() and hasAuthority('USER')")
@@ -41,7 +66,16 @@ public class ProductController {
         return productService.createProduct(productData);
     }
 
+    /**
+     * 로그인이 되어 있고, 등록된 상품중 id에 해당하는 상품의 정보를 수정하려는 요청을 처리합니다.
+     * 상태코드 200과 수정된 상품 정보를 응답합니다.
+     *
+     * @param id          상품의 id
+     * @param productData 수정하려는 상품 정보
+     * @return 수정된 상품 정보
+     */
     @PatchMapping("{id}")
+    @ResponseStatus(HttpStatus.OK)
     @PreAuthorize("isAuthenticated()")
     public Product update(
             @PathVariable Long id,
@@ -50,7 +84,14 @@ public class ProductController {
         return productService.updateProduct(id, productData);
     }
 
+    /**
+     * 로그인이 되어 있고,  등록된 상품중 id에 해당하는 상품 삭제 요청을 처리합니다
+     * 상태코드 204을 응답합니다
+     *
+     * @param id 상품 id
+     */
     @DeleteMapping("{id}")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
     @PreAuthorize("isAuthenticated()")
     public void destroy(@PathVariable Long id) {
         productService.deleteProduct(id);


### PR DESCRIPTION
Spring REST Docs 은
Spring MVC Test, WebTestClient 등 테스트에서 생성된 스니펫을 사용하여
RESTful 서비스에 대한 정확하고 읽기 쉬운 문서를 생성해 줍니다.

Swagger는 API 동작을 테스트하는 용도에 더 특화 되있으며
Spring Rest Docs은 테스트가 성공해야 문서가 작성되며 깔끔 명료한 문서를 만들 수 있습니다.

이번 PR에서는 상품 컨트롤러 Rest doc을 적용 했습니다.

- spring rest doc 공식 문서
https://docs.spring.io/spring-restdocs/docs/current/reference/html5/

- rest doc 문서작성은 아래 사이트를 참고했습니다.
https://developers.kakao.com/docs/latest/ko/kakaologin/rest-api#before-you-begin