### PR TITLE
javaDoc 및 API 문서 작성

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -80,6 +80,10 @@ dependencies {
     testImplementation('org.springframework.boot:spring-boot-starter-test') {
         exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'
     }
+
+    // Spring Security Test
+    testImplementation 'org.springframework.security:spring-security-test'
+
 }
 
 application {

--- a/app/src/main/java/com/codesoom/assignment/application/auth/LoginRequest.java
+++ b/app/src/main/java/com/codesoom/assignment/application/auth/LoginRequest.java
@@ -1,5 +1,6 @@
 package com.codesoom.assignment.application.auth;
 
+/** 로그인 요청 */
 public interface LoginRequest {
 
     String getEmail();

--- a/app/src/main/java/com/codesoom/assignment/application/auth/UserLoginService.java
+++ b/app/src/main/java/com/codesoom/assignment/application/auth/UserLoginService.java
@@ -8,6 +8,7 @@ import com.codesoom.assignment.utils.JwtUtil;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
+/** 회원 로그인을 담당합니다. */
 @Service
 public class UserLoginService implements AuthenticationService {
 

--- a/app/src/main/java/com/codesoom/assignment/controller/products/ProductDeleteController.java
+++ b/app/src/main/java/com/codesoom/assignment/controller/products/ProductDeleteController.java
@@ -1,8 +1,6 @@
 package com.codesoom.assignment.controller.products;
 
-import com.codesoom.assignment.application.auth.AuthorizationService;
 import com.codesoom.assignment.application.products.ProductDeleteService;
-import com.codesoom.assignment.config.AccessToken;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;

--- a/app/src/main/java/com/codesoom/assignment/controller/products/ProductUpdateController.java
+++ b/app/src/main/java/com/codesoom/assignment/controller/products/ProductUpdateController.java
@@ -1,11 +1,8 @@
 package com.codesoom.assignment.controller.products;
 
-import com.codesoom.assignment.application.auth.AuthorizationService;
 import com.codesoom.assignment.application.products.ProductSaveRequest;
 import com.codesoom.assignment.application.products.ProductUpdateService;
-import com.codesoom.assignment.config.AccessToken;
 import com.codesoom.assignment.domain.products.Product;
-import com.codesoom.assignment.domain.products.ProductDto;
 import org.springframework.http.HttpStatus;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.PathVariable;

--- a/app/src/main/java/com/codesoom/assignment/controller/session/SessionController.java
+++ b/app/src/main/java/com/codesoom/assignment/controller/session/SessionController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
+/** 회원 로그인 요청을 처리합니다. */
 @CrossOrigin
 @RequestMapping("/session")
 @RestController

--- a/app/src/main/java/com/codesoom/assignment/controller/session/SessionControllerAdvice.java
+++ b/app/src/main/java/com/codesoom/assignment/controller/session/SessionControllerAdvice.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+/** 로그인 요청에서 발생하는 예외를 처리합니다. */
 @RestControllerAdvice(basePackages = "com.codesoom.assignment.controller.session")
 public class SessionControllerAdvice {
 

--- a/app/src/main/java/com/codesoom/assignment/controller/users/UserUpdateController.java
+++ b/app/src/main/java/com/codesoom/assignment/controller/users/UserUpdateController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 
 import javax.validation.Valid;
 
+/** 회원 수정 요청을 처리합니다. */
 @UserController
 public class UserUpdateController {
 

--- a/app/src/main/java/com/codesoom/assignment/exceptions/InvalidPasswordException.java
+++ b/app/src/main/java/com/codesoom/assignment/exceptions/InvalidPasswordException.java
@@ -2,6 +2,7 @@ package com.codesoom.assignment.exceptions;
 
 import org.springframework.http.HttpStatus;
 
+/** 회원 로그인 요청 시 비밀번호가 불일치 할 경우 던집니다. */
 public class InvalidPasswordException extends RuntimeException {
 
     private String code;

--- a/app/src/main/java/com/codesoom/assignment/exceptions/InvalidTokenException.java
+++ b/app/src/main/java/com/codesoom/assignment/exceptions/InvalidTokenException.java
@@ -2,6 +2,7 @@ package com.codesoom.assignment.exceptions;
 
 import org.springframework.http.HttpStatus;
 
+/** 인증 토큰 유효성 검증 실패 시 던집니다. */
 public class InvalidTokenException extends RuntimeException {
 
     private String code;

--- a/app/src/main/java/com/codesoom/assignment/security/filter/JwtAuthenticationFilter.java
+++ b/app/src/main/java/com/codesoom/assignment/security/filter/JwtAuthenticationFilter.java
@@ -34,6 +34,9 @@ public class JwtAuthenticationFilter extends BasicAuthenticationFilter {
         this.authorizationService = authorizationService;
     }
 
+    /**
+     * HttpHeader에 인증 토큰이 있다면 토큰 검증 후 SecurityContextHolder에 인증 정보를 등록합니다.
+     */
     @Override
     protected void doFilterInternal(HttpServletRequest request,
                                     HttpServletResponse response,

--- a/app/src/main/java/com/codesoom/assignment/utils/JwtUtil.java
+++ b/app/src/main/java/com/codesoom/assignment/utils/JwtUtil.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Component;
 
 import java.security.Key;
 
+/** JWT 생성, 검증 담당 */
 @Component
 public class JwtUtil {
 


### PR DESCRIPTION
javaDoc과 Spring REST Docs를 이용한 API 문서를 작성했습니다.



### javaDoc
javaDoc이란 주석으로 작성된 코드 문서를 HTML 문서로 만들어주는 도구 입니다. 
기본 작성 법은 아래와 같으며, 더 자세한 내용은 하단에 링크를 달아두었으니 참고해주세요.
``` java
// one line
/** 주석으로 문서를 작성할 수 있습니다. */

// multi line
/**
 * 주석으로 문서를 작성할 수 있습니다. 
 * 여러 줄로 작성하는 것도 가능합니다.
 */
```

### Spring REST Docs
Spring REST Docs는 스프링 애플리케이션의 HTTP 엔드포인트에 대한 명세를 작성할 수 있도록 도와줍니다.
사용 법은 아래와 같으며, 더 자세한 내용은 하단의 공식문서 링크를 참조하시기 바랍니다.
1. REST Docs를 작성할 테스트 클래스 선언부에 `RestDocumentationExtension`을 적용합니다.
``` java
@ExtendWith(RestDocumentationExtension.class)
public SomeControllerTest {}
```
2. `@BeforeEach`메서드에서 MockMvc 세팅을 해주어야 합니다.
``` java
private MockMvc mockMvc;

@BeforeEach
public void setUp(WebApplicationContext webApplicationContext, 
                               RestDocumentationContextProvider restDocumentation) {
	this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
			.apply(documentationConfiguration(restDocumentation)) 
			.build();
}
```


**참고**
[javaDoc](https://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html)
[Spring REST Docs](https://docs.spring.io/spring-restdocs/docs/current/reference/html5/)
[Spring REST Docs 가이드](https://spring.io/guides/gs/testing-restdocs/)